### PR TITLE
README formatting, samples, and label fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ IntentSpec is a LaTeX package to facilitate writing requirements documents in th
 
 For a demonstration, look at intent_specifications_example.tex and compile it with the following commands:
 
+```
 latex intent_specifications_example.tex
 latex intent_specifications_example.tex
 dvipdf intent_specifications_example.dvi
+```
 
 Then open the resulting PDF in a viewer of your choice.
 

--- a/intent_specifications_full_sample_toc.tex
+++ b/intent_specifications_full_sample_toc.tex
@@ -1,0 +1,111 @@
+\documentclass[12pt]{report}
+\usepackage{intentspec}
+\begin{document}
+
+%%%
+%
+% From N. G. Leveson, "Intent specifications: an approach to building human-centered specifications," in IEEE Transactions on Software Engineering, vol. 26, no. 1, pp. 15-35, Jan. 2000, doi: 10.1109/32.825764. keywords: {Humans;Software systems;Programming;Design engineering;Psychology;Man machine systems;Software maintenance;Software design;Software debugging;Software performance},
+%
+% http://sunnyday.mit.edu/papers/intent-tse.pdf
+%
+%%%
+
+\tableofcontents
+
+\chapter{System Purpose}
+\section{Introduction}
+\section{Historical Perspective}
+\section{Environment}
+\subsection{Environmental Assumptions}
+\subsection{Environmental Constraints}
+\section{Operator}
+\subsection{Tasks and Procedures}
+\subsection{Pilot-TCAS Interface Requirements}
+\section{TCAS System Goals}
+\section{High-Level Functional Requirements}
+\section{System Limitations}
+\section{System Constraints}
+\subsection{General Constraints}
+\subsection{Safety-Related Constraints}
+\section{Hazard Analysis}
+
+\chapter{System Design Principles}
+\section{General Description}
+\section{TCAS System Components}
+\section{Surveillance and Collision Avoidance Logic}
+\subsection{General Concepts}
+\subsection{Surveillance}
+\subsection{Tracking}
+\subsection{Traffic Advisories}
+\subsection{Resolution Advisories}
+\subsection{TCAS/TCAS Coordination}
+\section{Performance Monitoring}
+\section{Pilot-TCAS Interface}
+\subsection{Controls}
+\subsection{Displays and Aural Annunciations}
+\section{Testing and Validation}
+\subsection{Simulations}
+\subsection{Experiments}
+\subsection{Other Validation Procedures and Results}
+
+\chapter{Blackbox Behavior}
+\section{Environment}
+\section{Flight Crew Requirements}
+\subsection{Tasks}
+\subsection{Operational Procedures}
+\section{Communication and Interfaces}
+\subsection{Pilot-TCAS Interface}
+\subsection{Message Formats}
+\subsection{Input Interfaces}
+\subsection{Output Interfaces}
+\subsection{Receiver, Transmitter, Antennas}
+\section{Behavioral Requirements}
+\subsection{Surveillance}
+\subsection{Collision Avoidance}
+\subsection{Performance Monitoring}
+\section{Testing Requirements}
+
+\chapter{Physical and Logical Function}
+\section{Human-Computer Interface Design}
+\section{Pilot Operations (Flight) Manual}
+\section{Software Design}
+\section{Physical Requirements}
+\subsection{Definition of Standard Conditions}
+\subsection{Performance Capability of Own Aircraft's Mode S Transponder}
+\subsection{Receiver Characteristics}
+\subsection{TCAS Transmitter Characteristics}
+\subsection{TCAS Transmitter Pulse Characteristics}
+\subsection{TCAS Pulse Decoder Characteristics}
+\subsection{Interfence Limiting}
+\subsection{Aircraft Suppression Bus}
+\subsection{TCAS Data Handling and Interfaces}
+\subsection{Bearing Estimation}
+\subsection{High-Density Techniques}
+\section{Hardware Design Specifications}
+\section{Verification Requirements}
+
+\chapter{Physical Realization}
+\section{Software}
+\section{Hardware Assembly Instructions}
+\section{Training Requirements (Plan)}
+\section{Maintenance Requirements}
+
+\appendix
+
+\chapter{Constant Definitions}
+
+\chapter{Table Definitions}
+
+\chapter{Reference Algorithms}
+
+\chapter{Physical Measurement Conventions}
+
+\chapter{Performance Requirements on Equipment that Interacts with TCAS}
+
+\chapter{Glossary}
+
+\chapter{Notation Guide}
+
+\chapter{Index}
+
+\end{document}

--- a/intent_specifications_template_toc.tex
+++ b/intent_specifications_template_toc.tex
@@ -1,0 +1,64 @@
+\documentclass[12pt]{report}
+\usepackage{intentspec}
+\begin{document}
+
+\tableofcontents
+
+\chapter{System Purpose}
+\section{Introduction}
+\section{Historical Perspective}
+\section{Environment}
+\subsection{Environmental Assumptions}
+\subsection{Environmental Constraints}
+\section{Operator}
+\subsection{Tasks and Procedures}
+\subsection{Interface Requirements}
+\section{System Goals}
+\section{High-Level Functional Requirements}
+\section{System Limitations}
+\section{System Constraints}
+\subsection{General Constraints}
+\subsection{Safety-Related Constraints}
+\section{Hazard Analysis}
+
+\chapter{System Design Principles}
+\section{General Description}
+\section{System Components}
+\section{Performance Monitoring}
+\section{Interface}
+\section{Testing and Validation}
+
+\chapter{Blackbox Behavior}
+\section{Environment}
+\section{Functional Requirements}
+\section{Communication and Interfaces}
+\section{Behavioral Requirements}
+\section{Testing Requirements}
+
+\chapter{Physical and Logical Function}
+\section{Interface Design}
+\section{Operations Manual}
+\section{Software Design}
+\section{Physical Requirements}
+\section{Hardware Design Specifications}
+\section{Verification Requirements}
+
+\chapter{Physical Realization}
+\section{Software}
+\section{Hardware Assembly Instructions}
+\section{Training Requirements (Plan)}
+\section{Maintenance Requirements}
+
+\appendix
+
+\chapter{Appendix A}
+
+\chapter{Appendix B}
+
+\chapter{Glossary}
+
+\chapter{Notation Guide}
+
+\chapter{Index}
+
+\end{document}

--- a/intentspec.sty
+++ b/intentspec.sty
@@ -29,6 +29,9 @@
   \renewcommand{\labelenumii}{\intentPrefix\arabic{enumi}.\arabic{enumii}}
   \renewcommand{\labelenumiii}{\intentPrefix\arabic{enumi}.\arabic{enumii}.\arabic{enumiii}}
   \renewcommand{\labelenumiv}{\intentPrefix\arabic{enumi}.\arabic{enumii}.\arabic{enumiii}.\arabic{enumiv}}
+  \makeatletter
+  \renewcommand\p@enumiii{\theenumi\theenumii}
+  \makeatother
 
   \begin{enumerate}
     \setlength{\itemsep}{7pt}


### PR DESCRIPTION
Fixed a minor formatting issue in the README, as well as an issue where labels for nested intentspec items were not being formatted properly. (Labels for e.g. G1.1.1 were incorrectly being formatted as G1.(1).1.)

Also added a sample intent spec table of contents from Nancy Leveson's Intent Specifications paper (http://sunnyday.mit.edu/papers/intent-tse.pdf) and a template table of contents for use by people starting to build intent specs based on her format.